### PR TITLE
bin: skip stream size check

### DIFF
--- a/bin/wof-format.go
+++ b/bin/wof-format.go
@@ -24,7 +24,7 @@ func main() {
 			return
 		}
 
-		if info.Mode()&os.ModeCharDevice != 0 || info.Size() <= 0 {
+		if (info.Mode() & os.ModeCharDevice) != 0 {
 			fmt.Println("Usage: cat input.geojson | wof-format > output.geojson")
 			os.Exit(1)
 			return


### PR DESCRIPTION
Following on from https://github.com/whosonfirst/go-whosonfirst-format/pull/4 this PR makes a subtle change to the `stat` check for `stdin` which removes the size check.

Streams don't really have a 'size' per se, removing the check allows pipes to work which have no initial chunks available.

Named pipe as example, but I guess this could also happen for slow networks etc.

```bash
mkfifo my_pipe
go run bin/wof-format.go <my_pipe
```

in another window:

```bash
cat feature.geojson >my_pipe
```