### PR TITLE
coerce: cast properties to specific types/encodings

### DIFF
--- a/cmd/wof-format.go
+++ b/cmd/wof-format.go
@@ -57,6 +57,9 @@ func main() {
 		return
 	}
 
+	// coerce types of properties (recursively)
+	feature.Properties = format.Coerce(feature.Properties, "$.properties")
+
 	outputBytes, err := format.FormatFeature(&feature)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to format feature: %s\n", err)

--- a/coerce.go
+++ b/coerce.go
@@ -1,0 +1,50 @@
+package format
+
+import (
+	"fmt"
+	"strings"
+
+	encoding "github.com/whosonfirst/go-whosonfirst-format/encoding"
+)
+
+func encode(path string, v interface{}) interface{} {
+	var _type = fmt.Sprintf("%T", v)
+
+	switch {
+	case path == "$.properties.lbl:max_zoom" && _type == "float64":
+		return encoding.Float{v.(float64), 1, 8}
+	case strings.HasPrefix(path, "$.properties.name:deu_x_preferred") && _type == "string":
+		return encoding.String{v.(string), ""}
+	}
+
+	return v
+}
+
+// type conversions
+func Coerce(value interface{}, path string) interface{} {
+
+	// collections
+	switch value.(type) {
+
+	// JSON object (string keys)
+	case map[string]interface{}:
+		var values = value.(map[string]interface{})
+		for k, v := range values {
+			values[k] = Coerce(v, fmt.Sprintf("%s.%s", path, k))
+		}
+		return values
+
+	// JSON array (numeric keys)
+	case []interface{}:
+		var values = value.([]interface{})
+		for k, v := range values {
+			values[k] = Coerce(v, fmt.Sprintf("%s[%d]", path, k))
+		}
+		return values
+
+	// scalar values
+	default:
+		return encode(path, value)
+
+	}
+}

--- a/encoding/Float.go
+++ b/encoding/Float.go
@@ -1,0 +1,29 @@
+package encoding
+
+import (
+	"bytes"
+	"strconv"
+)
+
+type Float struct {
+	Value float64
+	Min   int
+	Max   int
+}
+
+func (f Float) MarshalJSON() ([]byte, error) {
+
+	// format to maximum precision (use -1 for unlimited)
+	enc := []byte(strconv.FormatFloat(float64(f.Value), 'f', f.Max, 64))
+
+	// remove trailing 0s while maintaining $Min precision
+	if f.Min > -1 {
+		pos := bytes.IndexByte(enc, '.')
+		if f.Min == 0 {
+			return enc[:pos], nil
+		}
+		return enc[:pos+f.Min+1], nil
+	}
+
+	return enc, nil
+}

--- a/encoding/String.go
+++ b/encoding/String.go
@@ -1,0 +1,30 @@
+package encoding
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+type String struct {
+	Value            string
+	UnicodeNormalize string
+}
+
+func (s String) MarshalJSON() ([]byte, error) {
+	str := s.Value
+
+	switch strings.ToUpper(s.UnicodeNormalize) {
+	case "NFD":
+		str = norm.NFD.String(str)
+	case "NFC":
+		str = norm.NFC.String(str)
+	case "NFKD":
+		str = norm.NFKD.String(str)
+	case "NFKC":
+		str = norm.NFKC.String(str)
+	}
+
+	return []byte(fmt.Sprintf(`"%s"`, str)), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/sergi/go-diff v1.0.0 // indirect
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/tidwall/pretty v1.2.0
+	golang.org/x/text v0.3.7 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,9 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=


### PR DESCRIPTION
this is a DRAFT PR to experiment with how we might be able to more finely control the encoding of properties.

```bash
echo '{ "properties": { "lbl:max_zoom": 1, "name:deu_x_preferred": ["Köln"] } }' | go run ./cmd/wof-format.go
{
  "id": 0,
  "type": "",
  "properties": {
    "lbl:max_zoom": 1.0,
    "name:deu_x_preferred": [
      "Köln"
    ]
  },
  "bbox": null,
  "geometry": null
}
```