### PR TITLE
goreleaser: output binaries called wof-format

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,7 +2,10 @@ before:
   hooks:
     - go mod tidy
 builds:
-  - env:
+  -
+    id: wof-format
+    binary: wof-format
+    env:
       - CGO_ENABLED=0
     goos:
       - linux
@@ -10,12 +13,17 @@ builds:
       - darwin
     main: ./cmd
 archives:
-  - replacements:
+  -
+    id: wof-format
+    builds:
+      - wof-format
+    replacements:
       darwin: Darwin
       linux: Linux
       windows: Windows
       386: i386
       amd64: x86_64
+    format: binary
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
- Rename the output binary to `wof-format` for consistency
- Output binaries without being wrapped in a .zip