### PR TITLE
Add flags to `wof-format` to do check only or set output path

### DIFF
--- a/cmd/wof-format.go
+++ b/cmd/wof-format.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -11,49 +12,123 @@ import (
 )
 
 func main() {
+	flag.CommandLine.SetOutput(os.Stderr)
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [-check] [input]\n\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "Either provide a WOF feature on stdin:\ncat input.geojson | %s > output.geojson\n\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "Or provide a path to a WOF feature as the first argument:\n%s input.geojson > output.geojson\n\n", os.Args[0])
+		fmt.Fprintf(flag.CommandLine.Output(), "Optional arguments:\n\n")
+		flag.PrintDefaults()
+	}
+
+	checkFlag := flag.Bool("check", false, "exits silently with a non-zero status code if the file is not correctly formatted")
+	outputFlag := flag.String("output", "", "write the output to a file instead of stdout")
+	overwriteFlag := flag.Bool("overwrite", false, "overwrite the input file with the formatted output")
 	flag.Parse()
 
-	var reader *bufio.Reader
+	if *outputFlag != "" && *overwriteFlag {
+		fmt.Fprintf(os.Stderr, "You cannot combine the -output and -overwrite flags\n")
+		os.Exit(1)
+	}
 
-	if flag.NArg() == 0 {
-		info, err := os.Stdin.Stat()
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to open stdin: %s\n", err)
-			os.Exit(1)
-			return
-		}
+	if *checkFlag && *outputFlag != "" {
+		fmt.Fprintf(os.Stderr, "You cannot combine the -check and -output flags\n")
+		os.Exit(1)
+	}
 
-		if (info.Mode() & os.ModeCharDevice) != 0 {
-			fmt.Fprintf(os.Stderr, "Usage: cat input.geojson | wof-format > output.geojson\n")
-			os.Exit(1)
-			return
-		}
+	if *checkFlag && *overwriteFlag {
+		fmt.Fprintf(os.Stderr, "You cannot combine the -check and -overwrite flags\n")
+		os.Exit(1)
+	}
 
-		reader = bufio.NewReader(os.Stdin)
-	} else {
-		f, err := os.Open(flag.Arg(0))
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Unable to open file: %s\n", err)
-			os.Exit(1)
-			return
-		}
-
-		reader = bufio.NewReader(f)
+	path, reader, err := inputReader()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+		return
 	}
 
 	inputBytes, err := io.ReadAll(reader)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Unable to read: %s\n", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 		return
 	}
 
 	outputBytes, err := format.FormatBytes(inputBytes)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to format feature: %s\n", err)
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 		return
 	}
 
-	fmt.Fprintf(os.Stdout, "%s", outputBytes)
+	if *checkFlag {
+		if bytes.Equal(inputBytes, outputBytes) {
+			os.Exit(0)
+			return
+		}
+
+		if path != "" {
+			fmt.Fprintf(os.Stderr, "%s is not valid\n", path)
+		}
+
+		os.Exit(1)
+	}
+
+	reader.Close()
+
+	var output io.WriteCloser = os.Stdout
+
+	if *outputFlag != "" {
+		output, err = os.Create(*outputFlag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to open %s for writing\n", *outputFlag)
+			os.Exit(1)
+		}
+	}
+
+	if *overwriteFlag && path != "" {
+		output, err = os.Create(path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "unable to open %s for writing\n", *outputFlag)
+			os.Exit(1)
+		}
+	}
+
+	buffer := bufio.NewWriter(output)
+
+	_, err = buffer.Write(outputBytes)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to write\n")
+		os.Exit(1)
+	}
+
+	buffer.Flush()
+	output.Close()
+}
+
+func inputReader() (string, io.ReadCloser, error) {
+	if flag.NArg() == 0 {
+		info, err := os.Stdin.Stat()
+		if err != nil {
+			flag.Usage()
+			os.Exit(1)
+		}
+
+		if (info.Mode() & os.ModeCharDevice) != 0 {
+			flag.Usage()
+			os.Exit(1)
+		}
+
+		return "", os.Stdin, nil
+	}
+
+	path := flag.Arg(0)
+	f, err := os.Open(path)
+	if err != nil {
+		return path, nil, fmt.Errorf("unable to open file: %w", err)
+	}
+
+	return path, f, nil
 }


### PR DESCRIPTION
Added some flags to `wof-format` to make it easier to rewrite files quickly or perform a validation check on a specific file.

Supports e.g.

`wof-format -check foo.geojson`, returning status code 1 if the file isn't valid.

`wof-format -overwrite foo.geojson`, overwriting the existing file with a validated file.

`wof-format -output output.geojson input.geojson`, specifying the output directory instead of stdout.